### PR TITLE
Fix slow screenshot loading by adding priority to above-the-fold images

### DIFF
--- a/components/content/UnifiedContentHeader.tsx
+++ b/components/content/UnifiedContentHeader.tsx
@@ -232,6 +232,7 @@ export const UnifiedContentHeader: React.FC<UnifiedContentHeaderProps> = ({
             alt={title}
             fill
             className="object-cover opacity-20"
+            priority
           />
           <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/80 to-black" />
         </div>
@@ -254,6 +255,7 @@ export const UnifiedContentHeader: React.FC<UnifiedContentHeaderProps> = ({
             alt={title}
             fill
             className="object-cover"
+            priority
           />
         </div>
 
@@ -347,6 +349,7 @@ export const UnifiedContentHeader: React.FC<UnifiedContentHeaderProps> = ({
                 width={320}
                 height={240}
                 className="w-full h-auto group-hover:scale-105 transition-transform duration-300"
+                priority
               />
               <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300" />
               <div className="absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-black/40 backdrop-blur-sm rounded-md p-1.5">

--- a/components/projects/EnhancedProjectLayout.tsx
+++ b/components/projects/EnhancedProjectLayout.tsx
@@ -280,6 +280,7 @@ export const EnhancedProjectLayout: React.FC<EnhancedProjectLayoutProps> = ({
                 width={1200}
                 height={675}
                 className="w-full h-full object-cover"
+                priority
               />
             </div>
           </div>

--- a/components/projects/ProjectGallery.tsx
+++ b/components/projects/ProjectGallery.tsx
@@ -92,6 +92,7 @@ export const ProjectGallery: React.FC<ProjectGalleryProps> = ({
               fill
               className="object-cover transition-transform duration-300 group-hover:scale-105"
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              priority={index < 3}
             />
             {/* Overlay on hover */}
             <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300 flex items-center justify-center">


### PR DESCRIPTION
Next.js Image defaults to loading="lazy" which defers image loading until the element enters the viewport via IntersectionObserver. This caused a visible delay for project screenshots, header images, and gallery images that are immediately visible on page load. Adding priority preloads these images and disables lazy loading.

https://claude.ai/code/session_01DaKRMC3HWUHohF85UXhHiV